### PR TITLE
Fix: Resolve Konva TypeError and FilteringManager syntax error

### DIFF
--- a/src/ui/FilteringManager.js
+++ b/src/ui/FilteringManager.js
@@ -64,8 +64,9 @@ export class FilteringManager {
             type: 'isolation', // Consistent type for isolation filters
             name: `Isolated: ${tableName}`,
             description: `Showing table "${tableName}" and its direct connections.`,
-            apply: (data) // data here will be originalData when applyFilter is called after clearing
-            {
+            // The 'data' parameter to apply is the current schema being filtered.
+            // However, for this specific isolation, we always start from originalData.
+            apply: (data) => {
                 const tablesToShow = this.originalData.tables.filter(t => directlyConnectedTableNames.has(t.name));
                 // Filter relationships again based on the tablesToShow, ensuring both ends are present
                 const finalRelationships = relevantRelationships.filter(rel => {

--- a/src/visualization/KonvaERDRenderer.js
+++ b/src/visualization/KonvaERDRenderer.js
@@ -612,17 +612,29 @@ export class KonvaERDRenderer {
         tableGroup.on('mouseleave', (e) => {
             this.onTableMouseLeave(e, tableData);
             // Only hide if not over the button itself
-            const pointerPos = this.stage.getPointerPosition();
             const isolateBtn = tableGroup.findOne('.isolate-btn-group');
-            if (isolateBtn && pointerPos) {
-                const shape = isolateBtn.getIntersection(pointerPos);
-                if (!shape) { // If pointer is not over the button
-                    isolateBtn.visible(false);
-                    this.tablesLayer.batchDraw();
+            if (!isolateBtn) return;
+
+            const pointerPos = this.stage.getPointerPosition();
+            let mouseIsOverButton = false;
+
+            if (pointerPos && isolateBtn.isVisible()) { // Check only if button is visible
+                // Get button's absolute bounding box on the stage
+                const btnRect = isolateBtn.getClientRect({ relativeTo: this.stage });
+
+                if (
+                    pointerPos.x >= btnRect.x &&
+                    pointerPos.x <= btnRect.x + btnRect.width &&
+                    pointerPos.y >= btnRect.y &&
+                    pointerPos.y <= btnRect.y + btnRect.height
+                ) {
+                    mouseIsOverButton = true;
                 }
-            } else if (isolateBtn) { // If pointerPos is null (mouse left canvas)
-                 isolateBtn.visible(false);
-                 this.tablesLayer.batchDraw();
+            }
+
+            if (!mouseIsOverButton) {
+                isolateBtn.visible(false);
+                this.tablesLayer.batchDraw();
             }
         });
 


### PR DESCRIPTION
- Fixed `Uncaught TypeError: isolateBtn.getIntersection is not a function` in `KonvaERDRenderer.js`. The table group's mouseleave handler now correctly calculates the isolate button's absolute bounding box on the stage and checks the pointer position against it to determine visibility.
- Corrected a syntax error in `FilteringManager.js` within the `isolateSingleTable` method where a comment was misplaced in an arrow function definition.